### PR TITLE
Add optional maxLength parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ An implementation of the [BIP173 spec] for Segwit Bech32 address format.
   // => 1
 ```
 
+The lightning [BOLT #11 spec] can have longer inputs than the [BIP173 spec] allows. Use the positional maxLength parameter to override the validation.
+```dart
+  String paymentRequest = "lnbc1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq8rkx3yf5tcsyz3d73gafnh3cax9rn449d9p5uxz9ezhhypd0elx87sjle52x86fux2ypatgddc6k63n7erqz25le42c4u4ecky03ylcqca784w";
+  Bech32Codec codec = Bech32Codec();
+  Bech32 bech32 = codec.decode(
+    paymentRequest,
+    paymentRequest.length,
+  );
+  print("hrp: ${bech32.hrp}");
+  // => hrp: lnbc
+```
+
 ## Exceptions
 
 The specification defines a myriad of cases in which decoding and encoding 
@@ -40,3 +52,4 @@ always remain free for everybody to access.
 ## Thanks
 
 [BIP173 spec]: https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki
+[BOLT #11 spec]: https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md

--- a/example/main.dart
+++ b/example/main.dart
@@ -9,4 +9,15 @@ void main() {
 
   Segwit otherAddress = Segwit('bc', 1, [0, 0]);
   print(segwit.encode(otherAddress));
+
+  // Decode a lightning payment request
+  String paymentRequest =
+      "lnbc1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq8rkx3yf5tcsyz3d73gafnh3cax9rn449d9p5uxz9ezhhypd0elx87sjle52x86fux2ypatgddc6k63n7erqz25le42c4u4ecky03ylcqca784w";
+  Bech32Codec codec = Bech32Codec();
+  Bech32 bech32 = codec.decode(
+    paymentRequest,
+    paymentRequest.length,
+  );
+  print("hrp: ${bech32.hrp}");
+  print("data: ${bech32.data}");
 }

--- a/lib/src/bech32.dart
+++ b/lib/src/bech32.dart
@@ -11,18 +11,19 @@ class Bech32Codec extends Codec<Bech32, String> {
   Bech32Decoder get decoder => Bech32Decoder();
   Bech32Encoder get encoder => Bech32Encoder();
 
-  String encode(Bech32 data) {
-    return Bech32Encoder().convert(data);
+  String encode(Bech32 data, [maxLength = Bech32Validations.maxInputLength]) {
+    return Bech32Encoder().convert(data, maxLength);
   }
 
-  Bech32 decode(String data) {
-    return Bech32Decoder().convert(data);
+  Bech32 decode(String data, [maxLength = Bech32Validations.maxInputLength]) {
+    return Bech32Decoder().convert(data, maxLength);
   }
 }
 
 // This class converts a Bech32 class instance to a String.
 class Bech32Encoder extends Converter<Bech32, String> with Bech32Validations {
-  String convert(Bech32 input) {
+  String convert(Bech32 input,
+      [int maxLength = Bech32Validations.maxInputLength]) {
     var hrp = input.hrp;
     var data = input.data;
 
@@ -30,7 +31,7 @@ class Bech32Encoder extends Converter<Bech32, String> with Bech32Validations {
             data.length +
             separator.length +
             Bech32Validations.checksumLength >
-        Bech32Validations.maxInputLength) {
+        maxLength) {
       throw TooLong(
           hrp.length + data.length + 1 + Bech32Validations.checksumLength);
     }
@@ -62,8 +63,9 @@ class Bech32Encoder extends Converter<Bech32, String> with Bech32Validations {
 
 // This class converts a String to a Bech32 class instance.
 class Bech32Decoder extends Converter<String, Bech32> with Bech32Validations {
-  Bech32 convert(String input) {
-    if (input.length > Bech32Validations.maxInputLength) {
+  Bech32 convert(String input,
+      [int maxLength = Bech32Validations.maxInputLength]) {
+    if (input.length > maxLength) {
       throw TooLong(input.length);
     }
 

--- a/test/bech32_test.dart
+++ b/test/bech32_test.dart
@@ -1,3 +1,4 @@
+import 'package:bech32/src/bech32.dart';
 import "package:test/test.dart";
 
 import "package:bech32/bech32.dart";
@@ -15,6 +16,15 @@ void main() {
         "?1ezyfcl",
       ];
 
+      List<String> validBolt11 = [
+        "lnbc1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq8rkx3yf5tcsyz3d73gafnh3cax9rn449d9p5uxz9ezhhypd0elx87sjle52x86fux2ypatgddc6k63n7erqz25le42c4u4ecky03ylcqca784w",
+        "lnbc2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpuaztrnwngzn3kdzw5hydlzf03qdgm2hdq27cqv3agm2awhz5se903vruatfhq77w3ls4evs3ch9zw97j25emudupq63nyw24cg27h2rspfj9srp",
+        "lnbc20m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqscc6gd6ql3jrc5yzme8v4ntcewwz5cnw92tz0pc8qcuufvq7khhr8wpald05e92xw006sq94mg8v2ndf4sefvf9sygkshp5zfem29trqq2yxxz7",
+        "lntb20m1pvjluezhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqfpp3x9et2e20v6pu37c5d9vax37wxq72un98kmzzhznpurw9sgl2v0nklu2g4d0keph5t7tj9tcqd8rexnd07ux4uv2cjvcqwaxgj7v4uwn5wmypjd5n69z2xm3xgksg28nwht7f6zspwp3f9t",
+        "lnbc20m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqsfpp3qjmp7lwpagxun9pygexvgpjdc4jdj85fr9yq20q82gphp2nflc7jtzrcazrra7wwgzxqc8u7754cdlpfrmccae92qgzqvzq2ps8pqqqqqqpqqqqq9qqqvpeuqafqxu92d8lr6fvg0r5gv0heeeqgcrqlnm6jhphu9y00rrhy4grqszsvpcgpy9qqqqqqgqqqqq7qqzqj9n4evl6mr5aj9f58zp6fyjzup6ywn3x6sk8akg5v4tgn2q8g4fhx05wf6juaxu9760yp46454gpg5mtzgerlzezqcqvjnhjh8z3g2qqdhhwkj",
+        "lnbc25m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5vdhkven9v5sxyetpdees9q4pqqqqqqqqqqqqqqqqqqszk3ed62snp73037h4py4gry05eltlp0uezm2w9ajnerhmxzhzhsu40g9mgyx5v3ad4aqwkmvyftzk4k9zenz90mhjcy9hcevc7r3lx2sphzfxz7",
+      ];
+
       valid.forEach((vec) {
         test("decode static vector: $vec", () {
           expect(bech32.decode(vec), isNotNull);
@@ -24,6 +34,23 @@ void main() {
       valid.forEach((vec) {
         test("decode then encode static vector: $vec", () {
           expect(bech32.encode(bech32.decode(vec)), vec.toLowerCase());
+        });
+      });
+
+      validBolt11.forEach((req) {
+        test("decode BOLT11 String: ${req.substring(0, 90)}...", () {
+          expect(bech32.decode(req, req.length), isNotNull);
+        });
+      });
+
+      validBolt11.forEach((req) {
+        test("decode then encode BOLT11 String: ${req.substring(0, 90)}...",
+            () {
+          int l = req.length;
+          expect(
+            bech32.encode(bech32.decode(req, l), l),
+            req.toLowerCase(),
+          );
         });
       });
     });
@@ -89,6 +116,21 @@ void main() {
       test("empty hpr, case two", () {
         expect(() => bech32.decode("1qzzfhee"),
             throwsA(TypeMatcher<TooShortHrp>()));
+      });
+    });
+
+    group("length override", () {
+      test("valid maxLength parameter", () {
+        String str =
+            "lnbc1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq8rkx3yf5tcsyz3d73gafnh3cax9rn449d9p5uxz9ezhhypd0elx87sjle52x86fux2ypatgddc6k63n7erqz25le42c4u4ecky03ylcqca784w";
+        expect(() => bech32.decode(str, str.length + 5), isNotNull);
+      });
+
+      test("invalid maxLength parameter", () {
+        String str =
+            "lnbc1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq8rkx3yf5tcsyz3d73gafnh3cax9rn449d9p5uxz9ezhhypd0elx87sjle52x86fux2ypatgddc6k63n7erqz25le42c4u4ecky03ylcqca784w";
+        expect(() => bech32.decode(str, str.length - 5),
+            throwsA(TypeMatcher<TooLong>()));
       });
     });
   });


### PR DESCRIPTION
Hi,

For my lightning wallet I need to decode lightning network [BOLT #11](https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md) invoices. The spec uses bech32 encoding but allows for inputs longer than 90 characters. I've added an optional maxLength parameter to the de- and encoder with 90 as the default value. This should be backwards compatible.
