### PR TITLE
build(deps): bump upper version of convert to 3.1.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Library implementing Bitcoins BIP173 (Bech32 encoding) specificatio
 homepage: https://github.com/haarts/bech32
 
 dependencies:
-    convert: '>=1.0.0 <=3.0.0'
+    convert: '>=1.0.0 <3.1.0'
 
 dev_dependencies:
     hex: ^0.2.0


### PR DESCRIPTION
[convert 3.0.1](https://pub.dev/packages/convert/changelog) has been released. This commit ensures that future patch releases of convert will be supported until 3.1.0.