### PR TITLE
Update the convert package to ^3.1.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v0.2.2
+* Update the convert package to ^3.1.1.
+
 v0.2.1
 * Update the convert package (thanks Juneezee)
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: bech32
-version: 0.2.1
+version: 0.2.2
 description: Library implementing Bitcoins BIP173 (Bech32 encoding) specification in a Flutter friendly fashion.
 homepage: https://github.com/haarts/bech32
 
 dependencies:
-    convert: '>=1.0.0 <3.1.0'
+    convert: ^3.1.1
 
 dev_dependencies:
     hex: ^0.2.0


### PR DESCRIPTION
The convert package has another update. This results in dependency conflicts with other projects that use version 3.1.1 or higher, while bech32 support up to version 3.1.0.

Note: related to [issue 6 - depend on convert 3.1.1](https://github.com/haarts/bech32/issues/6).